### PR TITLE
Add support for organization

### DIFF
--- a/analytics/analytics_view.py
+++ b/analytics/analytics_view.py
@@ -17,7 +17,7 @@ from care.emr.api.viewsets.base import (
     EMRRetrieveMixin,
     EMRUpdateMixin,
 )
-from care.emr.models.organization import FacilityOrganizationUser
+from care.emr.models.organization import FacilityOrganizationUser, Organization, OrganizationUser
 from care.facility.models.facility import Facility
 from care.utils.shortcuts import get_object_or_404
 
@@ -25,6 +25,8 @@ from care.utils.shortcuts import get_object_or_404
 def get_context_object(user, instance, external_id):
     if instance.context_type == AnalyticsContexts.facility.value:
         return get_object_or_404(Facility, external_id=external_id)
+    elif instance.context_type == AnalyticsContexts.organization.value:
+        return get_object_or_404(Organization, external_id=external_id)
     return None
 
 
@@ -38,6 +40,13 @@ def authorize_analytics_config(user, instance, obj):
         ).exists()
     ):
         raise PermissionDenied("You are not authorized to access this analytics config")
+    elif (
+        instance.context_type == AnalyticsContexts.organization.value
+        and not OrganizationUser.objects.filter(
+            user=user, organization=obj
+        ).exists()
+    ):
+        raise PermissionDenied("You are not authorized to access this analytics config")
 
 
 def get_context(user, instance, obj):
@@ -45,6 +54,9 @@ def get_context(user, instance, obj):
     if instance.context_type == AnalyticsContexts.facility.value:
         context["facility_external_id"] = str(obj.external_id)
         context["facility_id"] = str(obj.id)
+    elif instance.context_type == AnalyticsContexts.organization.value:
+        context["organization_external_id"] = str(obj.external_id)
+        context["organization_id"] = str(obj.id)
     return context
 
 

--- a/analytics/resources.py
+++ b/analytics/resources.py
@@ -9,6 +9,7 @@ from care.emr.resources.base import EMRResource
 
 class AnalyticsContexts(str, Enum):
     facility = "facility"
+    organization = "organization"
 
 
 class BaseAnalyticsResource(EMRResource):


### PR DESCRIPTION
This pull request extends analytics functionality to support organizations in addition to facilities. The main changes add support for the "organization" context throughout the analytics code, ensuring that permissions and context objects are handled appropriately for both facilities and organizations.

Key changes include:

**Support for organization context:**

* Added "organization" as a valid value to the `AnalyticsContexts` enum in `resources.py`, enabling analytics operations to be scoped to organizations.
* Updated `get_context_object` in `analytics_view.py` to fetch an `Organization` object when the context type is "organization".

**Authorization and context handling:**

* Enhanced the `authorize_analytics_config` function to check that the user is an `OrganizationUser` when accessing analytics configs scoped to organizations, raising a permission error if not authorized.
* Updated the `get_context` function to include organization-specific keys (`organization_external_id` and `organization_id`) in the context dictionary when the context type is "organization".